### PR TITLE
dev-qt/qt-installer-framework: add missing DEPEND.

### DIFF
--- a/dev-qt/qt-installer-framework/qt-installer-framework-2.0.3.ebuild
+++ b/dev-qt/qt-installer-framework/qt-installer-framework-2.0.3.ebuild
@@ -23,6 +23,7 @@ RDEPEND=">=dev-qt/qtcore-${QT_PV}
 		 >=dev-qt/qtdeclarative-${QT_PV}
 	     "
 DEPEND="${RDEPEND}
+		dev-qt/designer
 		doc? ( >=dev-qt/qdoc-${QT_PV} )
 		test? ( >=dev-qt/qttest-${QT_PV} )
 	     "


### PR DESCRIPTION
`qt-installer-framework` requires `uitools` module, which can be found in `dev-qt/designer` according to [here](https://wiki.gentoo.org/wiki/Project:Qt/Qt5status).

Otherwise it may fail to build.

Signed-off-by: Wenxuan Zhao <viz@linux.com>